### PR TITLE
Bugfixes: January '21

### DIFF
--- a/chatFormat.js
+++ b/chatFormat.js
@@ -37,17 +37,6 @@ module.exports = function chatFormat(line, channel, client, serverConsoleName) {
                 `Player \`${player}\` has been BANNED by \`${doneBy}\` for reason \`${reason}\``
             );
     }
-    if (line.includes("[MUTED] ")) {
-        line = line.slice(line.indexOf("[MUTED] ") + "[MUTED] ".length);
-        line = line.split(" ");
-        const player = line[0];
-        const doneBy = line[4];
-        if (client.channels.cache.get(channel).name !== "dev-dump")
-            moderators.send(`Player \`${player}\` has been MUTED by \`${doneBy}\``);
-        return client.channels.cache
-            .get(channel)
-            .send(`Player \`${player}\` has been MUTED by \`${doneBy}\``);
-    }
     if (line.includes("[UNBANNED] ")) {
         line = line.slice(line.indexOf("[UNBANNED] ") + "[UNBANNED] ".length);
         line = line.split(" ");
@@ -58,17 +47,6 @@ module.exports = function chatFormat(line, channel, client, serverConsoleName) {
         return client.channels.cache
             .get(channel)
             .send(`Player \`${player}\` has been UNBANNED by \`${doneBy}\``);
-    }
-    if (line.includes("[UNMUTED] ")) {
-        line = line.slice(line.indexOf("[UNMUTED] ") + "[UNMUTED] ".length);
-        line = line.split(" ");
-        const player = line[0];
-        const doneBy = line[4];
-        if (client.channels.cache.get(channel).name !== "dev-dump")
-            moderators.send(`Player \`${player}\` has been UNMUTED by \`${doneBy}\``);
-        return client.channels.cache
-            .get(channel)
-            .send(`Player \`${player}\` has been UNMUTED by \`${doneBy}\``);
     }
 
     if (line.includes("Error")) {

--- a/commands/moderator/rconcmdall.js
+++ b/commands/moderator/rconcmdall.js
@@ -35,9 +35,15 @@ module.exports = {
           client.user.displayAvatarURL()
         );
       res.forEach((out) => {
-        if (out[0][1].startsWith("error"))
-          outEmbed.addField(`Server ${out[1]}`, out[0][1]);
-        else outEmbed.addField(`Server ${out[1]}`, out[0][0]);
+        try {
+          if (out[0][0].length > 1024) throw Error("Response too long!");
+          if (out[0][1].startsWith("error"))
+            outEmbed.addField(`Server ${out[1]}`, out[0][1]);
+          else outEmbed.addField(`Server ${out[1]}`, out[0][0]);
+        } catch (error) {
+          outEmbed.addField(`Server ${out[1]}`, error);
+          console.error(error);
+        }
       });
       return message.channel.send(outEmbed);
     }

--- a/commands/moderator/resetserver.js
+++ b/commands/moderator/resetserver.js
@@ -61,7 +61,7 @@ module.exports = {
         );
 
         if (!message.mentions.channels.first())
-            return message.channel.send("Please mention a channel  to wipe!");
+            return message.channel.send("Please mention a channel to wipe!");
 
         let sentMsg = await message.channel.send(
           `Please confirm wiping of server <#${
@@ -77,7 +77,7 @@ module.exports = {
           let messageReaction = await sentMsg
             .awaitReactions(filter, {
               max: 1,
-              time: 5000,
+              time: 10000,
               errors: ["time"],
             })
             .catch((err) => {

--- a/commands/moderator/resetserver.js
+++ b/commands/moderator/resetserver.js
@@ -123,6 +123,8 @@ module.exports = {
 
         // save stuff
         saveStuff: try {
+            if (!fs.existsSync(`${absPath}/${serverObject.serverFolderName}/saves/`))
+                fs.mkdirSync(`${absPath}/${serverObject.serverFolderName}/saves/`);
             let saves = await sortModifiedDate(
                 `${absPath}/${serverObject.serverFolderName}/saves`
             );
@@ -154,7 +156,6 @@ module.exports = {
         }
 
         commandArgs = []
-        command = `cd ${absPath}/${serverObject.serverFolderName} && ${absPath}/${serverObject.serverFolderName}/bin/x64/factorio`
         if (args.includes("--scenario")) {
             // user wants to start with a scenario
             let index = args.indexOf("--scenario")
@@ -180,11 +181,12 @@ module.exports = {
         }
 
         // spawn a new child slave to run the server setup
-        let server = child_process.spawn('./bin/x64/factorio', commandArgs, { cwd: `${absPath}/${serverObject.serverFolderName}` });
+        // let server = child_process.spawn('./bin/x64/factorio', commandArgs, { cwd: `${absPath}/${serverObject.serverFolderName}` });
+        let server = child_process.spawn('./bin/x64/factorio', ['--start-server-load-scenario', 'AwF-Scenario'], { cwd: `${absPath}/${serverObject.serverFolderName}` });
         let outputData = [];
         const serverStartRegExp = new RegExp(/Info ServerMultiplayerManager.cpp:\d\d\d: Matching server connection resumed/);
         server.stdout.on("data", (data) => {
-            // console.log(data.toString().slice(0, -1));
+            console.log(data.toString().slice(0, -1));
             outputData.push(`${data.toString().slice(0, -1)}`);
             if (data.toString().slice(0, -1).match(serverStartRegExp)) {
                 server.kill();
@@ -192,7 +194,7 @@ module.exports = {
             }
         });
         server.stderr.on("data", (data) => {
-            // console.log(data.toString().slice(0, -1));
+            console.log(data.toString().slice(0, -1));
             outputData.push(`${data.toString().slice(0, -1)}\n`);
         });
         server.on("close", async (code) => {

--- a/commands/moderator/sendall.js
+++ b/commands/moderator/sendall.js
@@ -1,4 +1,4 @@
-const { sendToAll } = require("../../functions");
+const { ServerFifoManager } = require("../../utils/fifo-manager");
 
 module.exports = {
   config: {
@@ -18,7 +18,7 @@ module.exports = {
       authRoles.some((r) => r.name === "dev")
     ) {
       message.content = message.content.slice(9); //prefixes the message with a / to start commands in Factorio
-      sendToAll(message, true); //sends the command to all servers with a username
+      ServerFifoManager.sendToAll(message, true); //sends the command to all servers with a username
       return message.channel
         .send("Success!")
         .then((message) => message.delete({ timeout: 5000 }));

--- a/commands/testing/spamfactorioserver.js
+++ b/commands/testing/spamfactorioserver.js
@@ -1,0 +1,31 @@
+const { Server } = require("mongodb");
+const serverJson = require("../../servers.json");
+const { ServerFifoManager } = require("../../utils/fifo-manager")
+
+module.exports = {
+    config: {
+        name: "spamfactorioserver",
+        aliases: [],
+        usage: "<server ping> <number of messages> [message to send]",
+        category: "testing",
+        description: "Spam a Factorio server with lots of chat stuff",
+        accessableby: "Admin",
+    },
+    run: async (client, message, args) => {
+        let authRoles = message.member.roles.cache;
+        if (
+            !authRoles.some((r) => ["Admin", "dev"].includes(r.name))
+        ) {
+            // if user is not Admin/Moderator/dev
+            return message.channel.send(
+                "You don't have enough priviliges to run this command!"
+            );
+        }
+        if (!message.mentions.channels.first()) return message.channel.send("Mention a channel to spam!");
+        if (!args[1] || !parseInt(args[1])) return message.channel.send("Specify how many messages!");
+        const toSpam = args.slice(2).join(" ");
+        for (let i = 0; i < parseInt(args[1]); i++) {
+            ServerFifoManager.sendToServer({ content: `${i + 1} attempt at spam..`, channel: { id: (message.mentions.channels.first()).id } }, false);
+        }
+    },
+};

--- a/events/guild/message.js
+++ b/events/guild/message.js
@@ -1,5 +1,5 @@
 const { prefix } = require("../../botconfig.json");
-const { sendToServer } = require("../../functions");
+const { ServerFifoManager } = require("../../utils/fifo-manager");
 
 module.exports = async (client, message) => {
     let args = message.content.slice(prefix.length).trim().split(/ +/g);
@@ -48,5 +48,5 @@ module.exports = async (client, message) => {
             );
         });
     }
-    sendToServer(message, true); // send the message to corresponding server
+    ServerFifoManager.sendToServer(message, true); // send the message to corresponding server
 };

--- a/events/guild/presenceUpdate.js
+++ b/events/guild/presenceUpdate.js
@@ -3,8 +3,6 @@ const { testbotid } = require("../../botconfig.json")
 
 module.exports = (client, oldPresence, newPresence) => {
     if (newPresence.userID == testbotid) {
-        // ServerFifoManager.checkDevServer(newPresence);
-        console.log(`user <@${newPresence.userID}> changed their presence to ${newPresence.status}`);
-        client.channels.cache.get("723280139982471247").send(`user <@${newPresence.userID}> changed their presence to ${newPresence.status}`);
+        ServerFifoManager.checkDevServer(newPresence);
     }
 }

--- a/events/guild/presenceUpdate.js
+++ b/events/guild/presenceUpdate.js
@@ -1,0 +1,10 @@
+const { ServerFifoManager } = require("../../utils/fifo-manager");
+const { testbotid } = require("../../botconfig.json")
+
+module.exports = (client, oldPresence, newPresence) => {
+    if (newPresence.userID == testbotid) {
+        // ServerFifoManager.checkDevServer(newPresence);
+        console.log(`user <@${newPresence.userID}> changed their presence to ${newPresence.status}`);
+        client.channels.cache.get("723280139982471247").send(`user <@${newPresence.userID}> changed their presence to ${newPresence.status}`);
+    }
+}

--- a/filterBan.js
+++ b/filterBan.js
@@ -2,12 +2,12 @@
  * @file Ban people who are on the full banlist from all servers
  */
 const banList = require("./banlist-full.json");
-const { sendToAll } = require("./functions");
+const { ServerFifoManager } = require("./utils/fifo-manager");
 
 function filterBan(user, channel, client) {
   let toSendChannel = client.channels.cache.get(channel);
   if (banList.find((users) => users.username === user)) {
-    sendToAll(`/ban ${user} Please visit http://awf.yt to contest your ban`);
+    ServerFifoManager.sendToAll(`/ban ${user} Please visit http://awf.yt to contest your ban`);
     console.log(`Banned user ${user}`);
     toSendChannel.send(
       `**Banned user ${user}**\nFurther joins are not real joins`

--- a/functions.js
+++ b/functions.js
@@ -1000,6 +1000,7 @@ async function discordLog(line, discordChannelID, discordClient) {
     discordClient.channels.cache.get(discordChannelID)
   );
   let embed = new MessageEmbed(objLine);
+  discordClient.channels.cache.get(discordChannelID).send(embed);
   return discordClient.channels.cache.get("697146357819113553").send(embed); // moderators channel
 }
 /**

--- a/functions.js
+++ b/functions.js
@@ -8,7 +8,7 @@ const MongoClient = require("mongodb").MongoClient;
 const lodash = require("lodash");
 const servers = require("./servers.json"); // tails, fifo, discord IDs etc.
 const { exec } = require("child_process");
-const { uri, rconport, rconpw, PastebinApiToken } = require("./botconfig.json");
+const { uri, rconport, rconpw, PastebinApiToken, testserverchannelid } = require("./botconfig.json");
 const Rcon = require("rcon-client");
 const { MessageEmbed } = require("discord.js");
 const { request } = require("http");
@@ -720,6 +720,7 @@ async function addResearch(server, research, level) {
 async function parseJammyLogger(line, channel) {
   //channel is a Discord channel object
   //this long asf function parses JammyLogger lines in the console and handles basic statistics
+  console.log(line);
   if (line.includes("DIED: ")) {
     line = line.slice("DIED: ".length);
     line = line.split(" "); //split at separation between username and death reson
@@ -994,13 +995,14 @@ async function awfLogging(line, discordChannelID, discordClient) {
 async function discordLog(line, discordChannelID, discordClient) {
   // example input
   // {"title":"C","description":"/c was used","color":"0x808080","fields":[{"name":"Server Details","value":"Server: ${serverName} Time: 1 days 0 hours 18 minutes\nTotal: 7 Online: 1 Admins: 1"},{"name":"By","value":"oof2win2","inline":true},{"name":"Details","value":"game.reload_script()","inline":true}]}
+  if (discordChannelID == testserverchannelid) return;
   let objLine = JSON.parse(line);
   objLine.fields[0].value = objLine.fields[0].value.replace(
     "${serverName}",
     discordClient.channels.cache.get(discordChannelID)
   );
   let embed = new MessageEmbed(objLine);
-  discordClient.channels.cache.get("697146357819113553").send(embed); // moderators channel
+  return discordClient.channels.cache.get("697146357819113553").send(embed); // moderators channel
 }
 /**
  * @async

--- a/functions.js
+++ b/functions.js
@@ -78,6 +78,7 @@ async function sortModifiedDate(dir) {
   return new Promise((resolve, reject) => {
     fs.readdir(dir, function (err, files) {
       if (err) reject(err);
+      if (!files) return resolve([])
       files = files
         .map(function (fileName) {
           return {

--- a/functions.js
+++ b/functions.js
@@ -720,7 +720,6 @@ async function addResearch(server, research, level) {
 async function parseJammyLogger(line, channel) {
   //channel is a Discord channel object
   //this long asf function parses JammyLogger lines in the console and handles basic statistics
-  console.log(line);
   if (line.includes("DIED: ")) {
     line = line.slice("DIED: ".length);
     line = line.split(" "); //split at separation between username and death reson
@@ -924,23 +923,22 @@ async function changePoints(user, built, time, death = 0) {
       points: 0,
     };
     res = pushData;
-  } else {
-    let replaceWith = lodash.cloneDeep(res);
-    if (replaceWith.time) replaceWith.time += time;
-    else replaceWith.time = time;
-    if (replaceWith.built) replaceWith.built += built;
-    else replaceWith.built = built;
-    if (death != 0) {
-      if (replaceWith.deaths) replaceWith.deaths += death;
-      else replaceWith.deaths = death;
-      replaceWith.points -= 100 * death; //-100pts for death
-    }
-    if (replaceWith.points == null) replaceWith.points = 0;
-    replaceWith.points += built;
-    replaceWith.points += (time / 60) * 50; //50 pts/h
-    await findOneAndReplaceDB("otherData", "globPlayerStats", res, replaceWith);
-    return [replaceWith, user];
   }
+  let replaceWith = lodash.cloneDeep(res);
+  if (replaceWith.time) replaceWith.time += time;
+  else replaceWith.time = time;
+  if (replaceWith.built) replaceWith.built += built;
+  else replaceWith.built = built;
+  if (death != 0) {
+    if (replaceWith.deaths) replaceWith.deaths += death;
+    else replaceWith.deaths = death;
+    replaceWith.points -= 100 * death; //-100pts for death
+  }
+  if (replaceWith.points == null) replaceWith.points = 0;
+  replaceWith.points += built;
+  replaceWith.points += (time / 60) * 50; //50 pts/h
+  await findOneAndReplaceDB("otherData", "globPlayerStats", res, replaceWith);
+  return [replaceWith, user];
 }
 
 /**

--- a/functions.js
+++ b/functions.js
@@ -119,7 +119,8 @@ function bubbleSort(arr) {
 }
 
 /**
- * @description Sends a message to only one server
+ * @description Sends a message to only one server. Use the new utils/fifo-manager class instead!
+ * @deprecated
  * @param {Object} message - Discord message object to send to Factorio server. Used for which server to send to by getting the server by channel ID
  * @param {bool} sendWithUsername - Whether to send with username or not
  */
@@ -145,7 +146,8 @@ function sendToServer(message, sendWithUsername) {
 }
 
 /**
- * @description Send a message to all servers (announcement or something)
+ * @description Send a message to all servers (announcement or something). Use the new utils/fifo-manager class instead!
+ * @deprecated
  * @param {Object} message - Message to send, format of DiscordMessage
  * @param {bool} sendWithUsername - Whether to send message with username or not
  */

--- a/functions.js
+++ b/functions.js
@@ -467,7 +467,7 @@ async function rconCommandAll(command) {
   });
   let promiseArray = serverNames.map((server) => {
     return new Promise((resolve) => {
-      rconCommand("/p o", server.name)
+      rconCommand(command, server.name)
         .then((res) => {
           if (!res[1].startsWith("error")) {
             resolve([res, server.name]);

--- a/handlers/command.js
+++ b/handlers/command.js
@@ -20,5 +20,5 @@ module.exports = (client) => {
   };
   // This is where different command folders are loaded
   // If you want to create a new category, add the category/folder name here
-  ["basic", "owner", "factorio", "moderator"].forEach((x) => load(x));
+  ["basic", "owner", "factorio", "moderator", "testing"].forEach((x) => load(x));
 };

--- a/index.js
+++ b/index.js
@@ -10,11 +10,16 @@ const { discordLog, awfLogging, datastoreInput } = require("./functions");
 const fs = require("fs");
 
 // remove all files from ./temp/ dir to prevent random bs
-let tempFiles = fs.readdirSync('./temp/')
-tempFiles.forEach(file => {
-    fs.rmSync(`./temp/${file}`);
-    console.log(`File ./temp/${file} removed!`)
-})
+try {
+  if (!fs.existsSync('./temp/')) fs.mkdirSync('./temp')
+  let tempFiles = fs.readdirSync('./temp/')
+  tempFiles.forEach(file => {
+      fs.rmSync(`./temp/${file}`);
+      console.log(`File ./temp/${file} removed!`)
+  });
+} catch (error) {
+  console.error(error);
+}
 
 let serverTails = [];
 let discordLoggingTails = [];

--- a/utils/fifo-manager.js
+++ b/utils/fifo-manager.js
@@ -63,8 +63,8 @@ class _ServerFifoManager {
         else
             toSend = `${message.content}`
         this.usedFifos.forEach((server) => {
-            if (server.discordChannelID === message.channel.id)
-                server.serverFifo.write(`${message.author.username}: ${message.content}`, () => {});
+            if (server.serverObject.discordChannelID === message.channel.id)
+                server.serverFifo.write(toSend, () => {});
         });
     }
     /**
@@ -79,7 +79,7 @@ class _ServerFifoManager {
         else
             toSend = `${message.content}`
         this.usedFifos.forEach((server) => {
-            server.serverFifo.write(`${message.author.username}: ${message.content}`, () => {});
+            server.serverFifo.write(toSend, () => {});
         });
     }
 }

--- a/utils/fifo-manager.js
+++ b/utils/fifo-manager.js
@@ -32,11 +32,10 @@ class _ServerFifoManager {
         if (newPresence.status != "offline") {
             this.usedFifos.forEach((server) => {
                 if (server.serverObject.dev == true) {
-                    this.unusedFifos.push(server);
-                    this.usedFifos.filter((currentFifo) => {
-                        if (currentFifo.serverObject.dev === false)
+                    this.usedFifos = this.usedFifos.filter((currentFifo) => {
+                        if (!currentFifo.serverObject.dev)
                             return currentFifo;
-                        if (currentFifo.serverObject.dev === true)
+                        if (currentFifo.serverObject.dev)
                             this.unusedFifos.push(currentFifo);
                     });
                 }
@@ -45,7 +44,7 @@ class _ServerFifoManager {
 
         // test bot is now offline
         if (newPresence.status == "offline") {
-            this.unusedFifos.filter((currentFifo) => {
+            this.unusedFifos = this.unusedFifos.filter((currentFifo) => {
                 this.usedFifos.push(currentFifo);
             })
         }
@@ -66,6 +65,7 @@ class _ServerFifoManager {
             if (server.serverObject.discordChannelID === message.channel.id)
                 server.serverFifo.write(toSend, () => {});
         });
+        return;
     }
     /**
      * @description Send a message to all servers (announcement or something)

--- a/utils/fifo-manager.js
+++ b/utils/fifo-manager.js
@@ -1,0 +1,90 @@
+const serversJSON = require("../servers.json"); // tails, fifo, discord IDs etc.
+const FIFO = require("fifo-js");
+
+/**
+ * This class manages the FIFO files for all servers, with their respective features for sending messages
+ * @class
+ * @constructor
+ * @public
+ */
+class _ServerFifoManager {
+    constructor () {
+        this.usedFifos = [];
+        this.unusedFifos = [];
+        let serverKeys = Object.keys(serversJSON);
+        serverKeys.forEach((server) => {
+            /**
+             * This is an array of all used FIFOs in the class. They are retrieved from the servers.json file
+             */
+            try {
+                this.usedFifos.push({
+                    serverFifo: new FIFO(serversJSON[server].serverFifo),
+                    serverObject: serversJSON[server],
+                });
+            } catch (error) {
+                console.error(error);
+            }
+        });
+    }
+
+    checkDevServer(newPresence) {
+        // test bot turned online
+        if (newPresence.status != "offline") {
+            this.usedFifos.forEach((server) => {
+                if (server.serverObject.dev == true) {
+                    this.unusedFifos.push(server);
+                    this.usedFifos.filter((currentFifo) => {
+                        if (currentFifo.serverObject.dev === false)
+                            return currentFifo;
+                        if (currentFifo.serverObject.dev === true)
+                            this.unusedFifos.push(currentFifo);
+                    });
+                }
+            });
+        }
+
+        // test bot is now offline
+        if (newPresence.status == "offline") {
+            this.unusedFifos.filter((currentFifo) => {
+                this.usedFifos.push(currentFifo);
+            })
+        }
+    }
+
+    /**
+     * @description Sends a message to only one server
+     * @param {Object} message - Discord message object to send to Factorio server. Used for which server to send to by getting the server by channel ID
+     * @param {bool} sendWithUsername - Whether to send with username or not
+     */
+    sendToServer(message, sendWithUsername) {
+        let toSend;
+        if (sendWithUsername === true)
+            toSend = `${message.author.username}: ${message.content}`
+        else
+            toSend = `${message.content}`
+        this.usedFifos.forEach((server) => {
+            if (server.discordChannelID === message.channel.id)
+                server.serverFifo.write(`${message.author.username}: ${message.content}`, () => {});
+        });
+    }
+    /**
+     * @description Send a message to all servers (announcement or something)
+     * @param {Object} message - Message to send, format of DiscordMessage
+     * @param {bool} sendWithUsername - Whether to send message with username or not
+     */
+    sendToAll(message, sendWithUsername) {
+        let toSend;
+        if (sendWithUsername === true)
+            toSend = `${message.author.username}: ${message.content}`
+        else
+            toSend = `${message.content}`
+        this.usedFifos.forEach((server) => {
+            server.serverFifo.write(`${message.author.username}: ${message.content}`, () => {});
+        });
+    }
+}
+
+let ServerFifoManager = new _ServerFifoManager()
+module.exports = {
+    ServerFifoManager,
+}


### PR DESCRIPTION
## Fixes #54: Database Roles
Database roles weren't working properly, as the role was added repeatedly. This was because if a player joined a server where they didn't have the role yet, it was instantly added to the database. Now, it is checked if the database already has the roles the player is being given before adding them to the database
## Fixes sorting by modified date without any folder contents crashing the bot
When `sortModifiedDate()` was given a folder that had no items in it, the function itself crashed. This wasn't ideal, so now it returns an empty array if the folder had no items (the behavior is like it was supposed to be)
## Bug and typo in #69 are now fixed
There was a time duration of 5s instead of 10s on the message reaction
Command didn't work if the `saves` folder didn't exist, the bot creates it now if it didn't exist
## #52 fixed
The result of this wasn't being returned properly, which was causing repeated errors when the scenario decided to output anything.
## #51 fixed hopefully
Jammy has had leftover processes, only on the development Factorio server though. This is now mitigated with Jammy turning off for the development server if AwF-Test-Bot turns online. Jammy turns logging back on if AwF-Test-Bot goes offline. Mostly fixed in 3c59ec4b0226279ad1a3c0e1e70069106360a0a4, a638440a90ce4ac29d46da146fd669a47a5f4bf9 and fbb38619eadbeac1f5744457a4ea7fc1c41e7e80
## Nice embeds sent to channels they come from
<img width="311" alt="Screenshot 2021-01-29 at 17 28 45" src="https://user-images.githubusercontent.com/23482862/106300995-72a49e80-6257-11eb-94f9-cb32a2794bd1.png">
MessageEmbeds, such as the one above, were until now sent only to the moderators channel. Now, they are being sent to the channel they came from too, instead of only text messages.