### PR TITLE
Feat: New error manager & bugfix

### DIFF
--- a/commands/factorio/onlineplayers.js
+++ b/commands/factorio/onlineplayers.js
@@ -2,6 +2,7 @@ const Discord = require("discord.js");
 const { RconConnectionManager } = require("../../utils/rcon-connection");
 const serverJson = require("../../servers.json");
 const { on } = require("npm");
+const { ErrorManager } = require('../../utils/error-manager')
 
 module.exports = {
   config: {
@@ -23,18 +24,26 @@ module.exports = {
         `© ${message.guild.me.displayName} | Developed by DistroByte & oof2win2 | Total Commands: ${client.commands.size}`,
         client.user.displayAvatarURL()
       );
-    
-    const res = await RconConnectionManager.rconCommandAll('/p o');
-    res.forEach((out) => {
-      try {
-        if (typeof (out[0]) == "object") throw out
-        if (out[0].length > 1024) throw Error("Response too long!");
-        else onlinePlayers.addField(`${out[1].discordChannelName}`, out[0]);
-      } catch (error) {
-        onlinePlayers.addField(`${out[1].discordChannelName}`, error);
-        console.error(error);
-      }
-    });
-    return message.channel.send(onlinePlayers);
+
+    try {
+      const res = await RconConnectionManager.rconCommandAll('/p o')
+          .catch(err => {
+            console.error(err);
+          });
+      res.forEach((out) => {
+        try {
+          if (typeof (out[0]) == "object") throw out
+          if (out[0].length > 1024) throw Error("Response too long!");
+          else onlinePlayers.addField(`${out[1].discordChannelName}`, out[0]);
+        } catch (error) {
+          onlinePlayers.addField(`${out[1].discordChannelName}`, error);
+          console.error(error);
+        }
+      });
+      return message.channel.send(onlinePlayers);
+    } catch (error) {
+      ErrorManager.Error(error)
+      return 
+    }
   },
 };

--- a/index.js
+++ b/index.js
@@ -60,7 +60,6 @@ client.prefix = prefix;
 client.login(token);
 
 setTimeout(async () => {
-  // RconConnectionManager.setJammyChannel((await client.channels.fetch(clientErrChannelID)));
   ErrorManager.setJammyErrChannel((await client.channels.fetch(clientErrChannelID)));
 }, 2500);
 

--- a/index.js
+++ b/index.js
@@ -4,10 +4,13 @@
 const { Client, Collection } = require("discord.js");
 var Tail = require("tail").Tail;
 const chatFormat = require("./chatFormat");
-const { token, prefix } = require("./botconfig.json");
+const { token, prefix, clientErrChannelID } = require("./botconfig.json");
 const servers = require("./servers.json"); // tails, fifo, discord IDs etc.
 const { discordLog, awfLogging, datastoreInput } = require("./functions");
 const fs = require("fs");
+
+// let { RconConnectionManager } = require("./utils/rcon-connection");
+let { ErrorManager } = require('./utils/error-manager')
 
 // remove all files from ./temp/ dir to prevent random bs
 try {
@@ -55,6 +58,11 @@ client.prefix = prefix;
 ["command", "event"].forEach((x) => require(`./handlers/${x}`)(client));
 
 client.login(token);
+
+setTimeout(async () => {
+  // RconConnectionManager.setJammyChannel((await client.channels.fetch(clientErrChannelID)));
+  ErrorManager.setJammyErrChannel((await client.channels.fetch(clientErrChannelID)));
+}, 2500);
 
 serverTails.forEach((element) => {
   element[0].on("line", function (line) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -226,6 +226,14 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "dbly-linked-list": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/dbly-linked-list/-/dbly-linked-list-0.3.4.tgz",
+      "integrity": "sha512-327vOlwspi9i1T3Kc9yZhRUR8qDdgMQ4HmXsFDDCQ/HTc3sNe7gnF5b0UrsnaOJ0rvmG7yBZpK0NoOux9rKYKw==",
+      "requires": {
+        "lodash.isequal": "^4.5.0"
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -493,6 +501,11 @@
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "memory-pager": {
       "version": "1.5.0",
@@ -2355,6 +2368,14 @@
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "queue-fifo": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/queue-fifo/-/queue-fifo-0.2.6.tgz",
+      "integrity": "sha512-rwlnZHAaTmWEGKC7ziasK8u4QnZW/uN6kSiG+tHNf/1GA+R32FArZi18s3SYUpKcA0Y6jJoUDn5GT3Anoc2mWw==",
+      "requires": {
+        "dbly-linked-list": "0.3.4"
+      }
     },
     "rcon-client": {
       "version": "4.2.3",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"npm": "^7.0.11",
 		"pastebin-js": "^1.0.6",
 		"pastebin-ts": "^1.2.0",
+		"queue-fifo": "^0.2.6",
 		"rcon-client": "^4.2.3",
 		"request": "^2.88.2",
 		"request-promise": "^4.2.6",

--- a/utils/error-manager.js
+++ b/utils/error-manager.js
@@ -1,6 +1,9 @@
+const Queue = require('queue-fifo');
+
 class _ErrorManager {
   constructor() {
     this._JammyErrChannel = undefined;
+    this._errorQueue = new Queue();
   }
   setJammyErrChannel (channel) {
     if (channel.name) this._JammyErrChannel = channel;
@@ -9,11 +12,39 @@ class _ErrorManager {
   async Error (error) {
     console.error(error);
     if (this._JammyErrChannel && error.description)
-      this._JammyErrChannel
+      return this._JammyErrChannel
         .send(`Error ${error.name}\nDescription: ${error.description}\nStack trace is available in error logs`);
     else if (this._JammyErrChannel) {
-      this._JammyErrChannel
+      return this._JammyErrChannel
         .send(`Error: ${error}`);
+    }
+    if (error.description)
+      this._errorQueue.enqueue(`Error ${error.name}\nDescription: ${error.description}\nStack trace is available in error logs`);
+    else
+      this._errorQueue.enqueue(`Error: ${error}`);
+    setTimeout(() => {
+      this._trySendErrors()
+    }, 5000);
+  }
+  async _trySendErrors() {
+    const tryConnection = () => {
+      setTimeout(() => {
+        this._trySendErrors();
+      }, 60000);
+    }
+    if (this._JammyErrChannel.name)
+      this._sendErrors();
+    else {
+      console.error("JammyErrorChannel not assigned!");
+      setTimeout(() => {
+        tryConnection();
+      });
+    }
+  }
+  async _sendErrors() {
+    while (this._errorQueue.isEmpty() === false) {
+      const toSend = this._errorQueue.dequeue();
+      this._JammyErrChannel.send(toSend);
     }
   }
 }

--- a/utils/error-manager.js
+++ b/utils/error-manager.js
@@ -1,0 +1,24 @@
+class _ErrorManager {
+  constructor() {
+    this._JammyErrChannel = undefined;
+  }
+  setJammyErrChannel (channel) {
+    if (channel.name) this._JammyErrChannel = channel;
+    else throw new Error("Incorrect channel!");
+  };
+  async Error (error) {
+    console.error(error);
+    if (this._JammyErrChannel && error.description)
+      this._JammyErrChannel
+        .send(`Error ${error.name}\nDescription: ${error.description}\nStack trace is available in error logs`);
+    else if (this._JammyErrChannel) {
+      this._JammyErrChannel
+        .send(`Error: ${error}`);
+    }
+  }
+}
+
+let ErrorManager = new _ErrorManager();
+module.exports = {
+  ErrorManager,
+}


### PR DESCRIPTION
There is now a new error manager, who's Discord channel is set in index.js and it logs errors to the console & the Discord channel. This error manager is not highly tested, but it has a queue that it tries to go through every minute if the channel name hasn't been set (might need to change the condition later)
Fixes a bug in `?po` command when a server is offline, as the command would get 'stuck' and not show any feedback, now it shows that the specific server has had an error.