### PR TITLE
Another bugfix!

### DIFF
--- a/commands/moderator/rconcmd.js
+++ b/commands/moderator/rconcmd.js
@@ -36,11 +36,11 @@ module.exports = {
       const cmdArr = args.slice(1);
       const command = cmdArr.join(" ");
       let res = await RconConnectionManager.rconCommand(command, server);
-      if (res[1] == "error")
+      if (typeof(res) == "object")
         return message.channel.send(
-          `Error. Command may have worked, but didn't give a response: ${res[0]}`
+          `Error. Command may have worked, but didn't give a response: ${res}`
         );
-      return message.channel.send(`Command worked. Output: \n \`${res[0]}\``);
+      return message.channel.send(`Command worked. Output: \n \`${res}\``);
     }
   },
 };


### PR DESCRIPTION
So I should probably test all parts of code before pushing & creating a PR, that would allow me to avoid issues that are fixed with commits such as feaa2b7.
Anyways, this PR fixes the `?rconcmd` only showing the 0th character of output instead of the whole output